### PR TITLE
MAINT: stats.moment: minor fixes

### DIFF
--- a/scipy/stats/_stats_py.py
+++ b/scipy/stats/_stats_py.py
@@ -1099,12 +1099,13 @@ def _moment(a, moment, axis, *, mean=None):
     if a.size == 0:
         return np.mean(a, axis=axis)
 
-    if moment == 0 or moment == 1:
+    dtype = a.dtype.type if a.dtype.kind in 'fc' else np.float64
+
+    if moment == 0 or (moment == 1 and mean is None):
         # By definition the zeroth moment about the mean is 1, and the first
         # moment is 0.
         shape = list(a.shape)
         del shape[axis]
-        dtype = a.dtype.type if a.dtype.kind in 'fc' else np.float64
 
         if len(shape) == 0:
             return dtype(1.0 if moment == 0 else 0.0)
@@ -1123,7 +1124,8 @@ def _moment(a, moment, axis, *, mean=None):
             n_list.append(current_n)
 
         # Starting point for exponentiation by squares
-        mean = a.mean(axis, keepdims=True) if mean is None else mean
+        mean = (a.mean(axis, keepdims=True) if mean is None
+                else dtype(mean))
         a_zero_mean = a - mean
 
         eps = np.finfo(a_zero_mean.dtype).resolution * 10

--- a/scipy/stats/tests/test_stats.py
+++ b/scipy/stats/tests/test_stats.py
@@ -3016,7 +3016,7 @@ class TestMoments:
         y = stats.moment(self.testcase, 3, center=2)
         assert_approx_equal(y, 2)
         # Compare against the naive np.sum implementation:
-        x = self.testmathworks
+        x = np.asarray(self.testmathworks)
         y = stats.moment(x, 3, center=0)
         assert_approx_equal(y, np.sum(x**3)/len(x))
         y = stats.moment(x, 2, center=0)


### PR DESCRIPTION
Minimal adjustments to fix `ValueError` when `moment > 1` and to calculate the moment correctly when `moment == 1`.